### PR TITLE
feat: added missing types and re-ordered Change log types order

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@
 
 The default changelog generator for [go-semantic-release](https://github.com/go-semantic-release/semantic-release).
 
+## Output of the Change Log
+
+Changelog-generator will order the types of commits in the Change Log in the following order:
+- Breaking Changes
+- Feature
+- Bug Fixes
+- Reverts
+- Performance Improvements
+- Documentation
+- Tests
+- Code Refactoring
+- Styles
+- Chores
+- Build
+- CI
+
+[Example Change Log](./examples/GENERATED_CHANGELOG.md)
+
 ## Licence
 
 The [MIT License (MIT)](http://opensource.org/licenses/MIT)

--- a/examples/GENERATED_CHANGELOG.md
+++ b/examples/GENERATED_CHANGELOG.md
@@ -1,0 +1,33 @@
+## 2.0.0 (2020-11-11)
+
+#### Breaking Changes
+
+* commit message (12345678)
+```
+BREAKING CHANGE: test
+```
+* **user:** another commit message (12345679)
+```
+changed ID int into UUID
+```
+
+#### Feature
+
+* **app:** commit message (12345678)
+
+#### Bug Fixes
+
+* commit message (abcd)
+
+#### Build
+
+* commit message (43218765)
+
+#### CI
+
+* commit message (87654321)
+
+#### yolo
+
+* **swag:** commit message (12345678)
+

--- a/pkg/generator/changelog_generator.go
+++ b/pkg/generator/changelog_generator.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -27,26 +26,61 @@ func formatCommit(c *semrel.Commit) string {
 }
 
 var typeToText = map[string]string{
+	"%%bc%%":   "Breaking Changes",
 	"feat":     "Feature",
 	"fix":      "Bug Fixes",
-	"perf":     "Performance Improvements",
 	"revert":   "Reverts",
+	"perf":     "Performance Improvements",
 	"docs":     "Documentation",
-	"style":    "Styles",
-	"refactor": "Code Refactoring",
 	"test":     "Tests",
+	"refactor": "Code Refactoring",
+	"style":    "Styles",
 	"chore":    "Chores",
-	"%%bc%%":   "Breaking Changes",
+	"build":    "Build",
+	"ci":       "CI",
+}
+
+var typeOrder = map[int]string{
+	0:  "%%bc%%",
+	1:  "feat",
+	2:  "fix",
+	3:  "revert",
+	4:  "perf",
+	5:  "docs",
+	6:  "test",
+	7:  "refactor",
+	8:  "style",
+	9:  "chore",
+	10: "build",
+	11: "ci",
 }
 
 func getSortedKeys(m *map[string]string) []string {
+	types := make(map[int]string, len(*m))
 	keys := make([]string, len(*m))
+
 	i := 0
 	for k := range *m {
-		keys[i] = k
+		types[i] = k
 		i++
 	}
-	sort.Strings(keys)
+
+	i = 0
+	for ki := 0; ki < len(typeOrder); ki++ {
+		for ti := range types {
+			if types[ti] == typeOrder[ki] {
+				keys[i] = types[ti]
+				delete(types, ti)
+				i++
+			}
+		}
+	}
+
+	for ti := range types {
+		keys[i] = types[ti]
+		i++
+	}
+
 	return keys
 }
 
@@ -74,7 +108,7 @@ func (*DefaultChangelogGenerator) Generate(changelogConfig *generator.ChangelogG
 			break
 		}
 		if commit.Change != nil && commit.Change.Major {
-			typeScopeMap["%%bc%%"] += fmt.Sprintf("%s\n```%s\n```\n", formatCommit(commit), strings.Join(commit.Raw[1:], "\n"))
+			typeScopeMap["%%bc%%"] += fmt.Sprintf("%s```\n%s\n```\n", formatCommit(commit), strings.Join(commit.Raw[1:], "\n"))
 			continue
 		}
 		if commit.Type == "" {

--- a/pkg/generator/changelog_generator_test.go
+++ b/pkg/generator/changelog_generator_test.go
@@ -14,8 +14,11 @@ func TestDefaultGenerator(t *testing.T) {
 		{},
 		{SHA: "123456789", Type: "feat", Scope: "app", Message: "commit message"},
 		{SHA: "abcd", Type: "fix", Scope: "", Message: "commit message"},
+		{SHA: "87654321", Type: "ci", Scope: "", Message: "commit message"},
+		{SHA: "43218765", Type: "build", Scope: "", Message: "commit message"},
 		{SHA: "12345678", Type: "yolo", Scope: "swag", Message: "commit message"},
 		{SHA: "12345678", Type: "chore", Scope: "", Message: "commit message", Raw: []string{"", "BREAKING CHANGE: test"}, Change: &semrel.Change{Major: true}},
+		{SHA: "12345679", Type: "chore!", Scope: "user", Message: "another commit message", Raw: []string{"another commit message", "changed ID int into UUID"}, Change: &semrel.Change{Major: true}},
 		{SHA: "stop", Type: "chore", Scope: "", Message: "not included"},
 	}
 	changelogConfig.LatestRelease = &semrel.Release{SHA: "stop"}
@@ -25,7 +28,9 @@ func TestDefaultGenerator(t *testing.T) {
 	if !strings.Contains(changelog, "* **app:** commit message (12345678)") ||
 		!strings.Contains(changelog, "* commit message (abcd)") ||
 		!strings.Contains(changelog, "#### yolo") ||
-		!strings.Contains(changelog, "```BREAKING CHANGE: test\n```") ||
+		!strings.Contains(changelog, "#### Build") ||
+		!strings.Contains(changelog, "#### CI") ||
+		!strings.Contains(changelog, "```\nBREAKING CHANGE: test\n```") ||
 		strings.Contains(changelog, "not included") {
 		t.Fail()
 	}


### PR DESCRIPTION
Added missing types:
- `build`
- `ci`

Change Cog content is every time in a specific predefined order:
- Breaking Changes
- Feature
- Bug Fixes
- Reverts
- Performance Improvements
- Documentation
- Styles
- Code Refactoring
- Tests
- Chores
- Build
- CI

...having the 3 most important parts (major (breaking changes), minor (features) and patch (fixes)) first and less important/relevant information (as well as non predefined types) at the bottom of the Change Log.