### PR TITLE
fix: Annotations README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Additionally, the following functions are available:
 | Template                                                                                                                                       | Example Output                                             |
 |------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
 | `* {{with .Scope -}} **{{.}}:** {{end}} {{- .Message}} ({{trimSHA .SHA}})`                                                                     | `* **app:** commit message (12345678)`                     |
-| `* {{with .Scope -}} **{{.}}:** {{end}} {{- .Message}} ({{trimSHA .SHA}}) {{- with index .Annotations "author_login" }} - by @{{.}} {{- end}}` | `* **app:** commit message (12345678) - by @commit-author` |
+| `* {{with .Scope -}} **{{.}}:** {{end}} {{- .Message}} ({{trimSHA .SHA}}) {{- with index .Annotations."author_login" }} - by @{{.}} {{- end}}` | `* **app:** commit message (12345678) - by @commit-author` |
 
 
 ## Licence


### PR DESCRIPTION
There  was a "." missing in .Annotations."author_login" - otherwise author_login is interpreted to be a function ([go-semantic-release]: failed to parse commit template: template: commit-template:1: function "author_login" not defined) and not an item in the map