### PR TITLE
feat: configurable types

### DIFF
--- a/pkg/generator/changelog_generator_test.go
+++ b/pkg/generator/changelog_generator_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 	"text/template"
 
@@ -122,4 +124,26 @@ func TestFormatCommitWithCustomTemplate(t *testing.T) {
 	changelog := clGen.Generate(testChangelogConfig)
 	require.Contains(t, changelog, "* `12345678` - commit message [by @test]")
 	require.NotContains(t, changelog, "* `deadbeef` - commit message (deadbeef) [by @test]")
+}
+
+func TestFormatCommitWithCustomTypes(t *testing.T) {
+	myTypes := make(ChangelogTypes, len(defaultTypes))
+	copy(myTypes, defaultTypes)
+	for ix, clTy := range myTypes {
+		if clTy.Type == "feat" {
+			myTypes[ix].Text = "New Features"
+			break
+		}
+	}
+	typesFile, err := os.CreateTemp("", "changelog_types_*.json")
+	require.NoError(t, err)
+	defer os.Remove(typesFile.Name())
+	err = json.NewEncoder(typesFile).Encode(myTypes)
+	require.NoError(t, err)
+
+	clGen := &DefaultChangelogGenerator{}
+	require.NoError(t, clGen.Init(map[string]string{"types_path": typesFile.Name()}))
+	changelog := clGen.Generate(testChangelogConfig)
+	require.Contains(t, changelog, "#### New Features")
+	require.NotContains(t, changelog, "#### Feature")
 }

--- a/pkg/generator/changelog_generator_test.go
+++ b/pkg/generator/changelog_generator_test.go
@@ -140,6 +140,7 @@ func TestFormatCommitWithCustomTypes(t *testing.T) {
 	defer os.Remove(typesFile.Name())
 	err = json.NewEncoder(typesFile).Encode(myTypes)
 	require.NoError(t, err)
+	typesFile.Close()
 
 	clGen := &DefaultChangelogGenerator{}
 	require.NoError(t, clGen.Init(map[string]string{"types_path": typesFile.Name()}))

--- a/pkg/generator/changelog_types.go
+++ b/pkg/generator/changelog_types.go
@@ -9,9 +9,13 @@ type ChangelogType struct {
 
 type ChangelogTypes []ChangelogType
 
-func NewChangelogTypes() ChangelogTypes {
-	ret := make(ChangelogTypes, len(defaultTypes))
-	copy(ret, defaultTypes)
+func NewChangelogTypes(overrideTypes *ChangelogTypes) ChangelogTypes {
+	src := &defaultTypes
+	if overrideTypes != nil {
+		src = overrideTypes
+	}
+	ret := make(ChangelogTypes, len(*src))
+	copy(ret, *src)
 	return ret
 }
 


### PR DESCRIPTION
Add `types_path` configuration option that allows users to override the list of types used by the changelog generator. If specified, the this file is opened and parsed as JSON and will override the default types.

Resolves #8 